### PR TITLE
Modified TeXlyre links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "texlyre",
 	"private": true,
-	"version": "0.2.18",
+	"version": "0.2.19",
 	"description": "A local-first LaTeX web editor with real-time collaboration.",
 	"author": "Fares Abawi <fares@abawi.me> (https://abawi.me)",
 	"license": "AGPL-3.0-or-later",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = `texlyre-v0.2.18`; //`texlyre-v${process.env.npm_package_version || '1'}`;
+const CACHE_NAME = `texlyre-v0.2.19`; //`texlyre-v${process.env.npm_package_version || '1'}`;
 const BASE_PATH = '/texlyre/';
 
 console.log('[ServiceWorker] Service Worker loading with base path:', BASE_PATH);

--- a/src/components/app/AuthApp.tsx
+++ b/src/components/app/AuthApp.tsx
@@ -69,17 +69,17 @@ const AuthApp: React.FC<AuthContainerProps> = ({ onAuthSuccess }) => {
 		  <footer className="auth-footer">
 			 <p className="read-the-docs">
 				Built with TeXlyre
-				<a href="https://texlyre.github.io/texlyre/" target="_blank" rel="noreferrer">
+				<a href="https://texlyre.github.io" target="_blank" rel="noreferrer">
 				   <img src={texlyreLogo} className="logo" alt="TeXlyre logo" />
 				</a>
 				 <span className="legal-links">
-				  <br/> <a href="https://github.com/TeXlyre/texlyre/blob/main/LICENSE" target="_blank" rel="noreferrer">
-					AGPL-3.0 License
+				  <br/> <a href="https://texlyre.github.io/docs/intro" target="_blank" rel="noreferrer">
+					Documentation
 				  </a>
 					{" "} • <a href="https://github.com/TeXlyre/texlyre" target="_blank" rel="noreferrer">
 					Source Code
 				  </a>
-				  {" "} • <a href="#" onClick={() => setShowPrivacy(true)} className="privacy-link">
+				  {" "} • <a href="javascript:void(0)" onClick={() => setShowPrivacy(true)} className="privacy-link">
 					Privacy
 				  </a>
 				</span>

--- a/src/components/app/EditorApp.tsx
+++ b/src/components/app/EditorApp.tsx
@@ -465,17 +465,17 @@ const EditorAppView: React.FC<EditorAppProps> = ({
 			<footer>
 			  <p className="read-the-docs">
 				Built with TeXlyre
-				<a href="https://texlyre.github.io/texlyre/" target="_blank" rel="noreferrer">
+				<a href="https://texlyre.github.io" target="_blank" rel="noreferrer">
 				  <img src={texlyreLogo} className="logo" alt="TeXlyre logo" />
 				</a>
 				<span className="legal-links">
-				  <br/> <a href="https://github.com/TeXlyre/texlyre/blob/main/LICENSE" target="_blank" rel="noreferrer">
-					AGPL-3.0 License
+				  <br/> <a href="https://texlyre.github.io/docs/intro" target="_blank" rel="noreferrer">
+					Documentation
 				  </a>
 					{" "} • <a href="https://github.com/TeXlyre/texlyre" target="_blank" rel="noreferrer">
 					Source Code
 				  </a>
-				  {" "} • <a href="#" onClick={() => setShowPrivacy(true)} className="privacy-link">
+				  {" "} • <a href="javascript:void(0)" onClick={() => setShowPrivacy(true)} className="privacy-link">
 					Privacy
 				  </a>
 				</span>

--- a/src/components/app/ProjectApp.tsx
+++ b/src/components/app/ProjectApp.tsx
@@ -338,7 +338,7 @@ const ProjectApp: React.FC<ProjectManagerProps> = ({
 
 				<div className="header-center">
 					<a
-						href="https://texlyre.github.io/texlyre/"
+						href="https://texlyre.github.io"
 						target="_blank"
 						rel="noreferrer"
 					>
@@ -427,17 +427,17 @@ const ProjectApp: React.FC<ProjectManagerProps> = ({
 			<footer>
 				<p className="read-the-docs">
 					Built with TeXlyre
-					<a href="https://texlyre.github.io/texlyre/" target="_blank" rel="noreferrer">
+					<a href="https://texlyre.github.io" target="_blank" rel="noreferrer">
 						<img src={texlyreLogo} className="logo" alt="TeXlyre logo" />
 					</a>
 					<span className="legal-links">
-					  <br/> <a href="https://github.com/TeXlyre/texlyre/blob/main/LICENSE" target="_blank" rel="noreferrer">
-						AGPL-3.0 License
+					  <br/> <a href="https://texlyre.github.io/docs/intro" target="_blank" rel="noreferrer">
+						Documentation
 					  </a>
 						{" "} • <a href="https://github.com/TeXlyre/texlyre" target="_blank" rel="noreferrer">
 						Source Code
 					  </a>
-					  {" "} • <a href="#" onClick={() => setShowPrivacy(true)} className="privacy-link">
+					  {" "} • <a href="javascript:void(0)" onClick={() => setShowPrivacy(true)} className="privacy-link">
 						Privacy
 					  </a>
 					</span>


### PR DESCRIPTION
Adjusted links to refer to TeXlyre landing page, replaced license link with documentation link, and linked to privacy-policy modal from URL