### PR TITLE
Fix GitHub import UTF-8 decoding

### DIFF
--- a/extras/backup/forgejo/ForgejoBackupService.ts
+++ b/extras/backup/forgejo/ForgejoBackupService.ts
@@ -98,6 +98,8 @@ const forgejoBackupAdapter: GitBackupAdapter<ForgejoTarget> = {
             branch,
         ),
 
+    getFileRefForPath: (_item: GitTreeItem, path: string) => path,
+
     readFile: (token, target, path, branch) =>
         forgejoAPIService.getFileContent(
             token,

--- a/extras/backup/gitea/GiteaBackupService.ts
+++ b/extras/backup/gitea/GiteaBackupService.ts
@@ -98,7 +98,7 @@ const giteaBackupAdapter: GitBackupAdapter<GiteaTarget> = {
             branch,
         ),
 
-    getFileRefForPath: (item: GitTreeItem) => item.sha || item.path || '',
+    getFileRefForPath: (_item: GitTreeItem, path: string) => path,
 
     readFile: (token, target, path, branch) =>
         giteaAPIService.getFileContent(

--- a/scripts/generate-plugins-index.js
+++ b/scripts/generate-plugins-index.js
@@ -1,7 +1,7 @@
 // scripts/generate-plugins-index.js
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,7 +9,7 @@ const rootDir = path.join(__dirname, '..');
 
 async function loadConfig() {
     const configPath = path.join(rootDir, 'texlyre.config.ts');
-    const { default: config } = await import(configPath);
+    const { default: config } = await import(pathToFileURL(configPath).href);
     return config;
 }
 

--- a/src/services/GitBackupService.ts
+++ b/src/services/GitBackupService.ts
@@ -719,7 +719,8 @@ export class GitBackupService<TTarget> {
                         finalBranch,
                     );
 
-                    const projectMetadata = JSON.parse(
+                    const projectMetadata = this.normalizeProjectMetadata(
+                        missingProjId,
                         this.decodeRemoteTextContent(metadataContent),
                     );
 
@@ -753,7 +754,7 @@ export class GitBackupService<TTarget> {
                         type: 'import_error',
                         message: t('Failed to import missing project: {missingProjId}', {
                             missingProjId,
-                        }),
+                        }) + ` (${this.getErrorMessage(error)})`,
                     });
                 }
             }
@@ -768,7 +769,8 @@ export class GitBackupService<TTarget> {
                     finalBranch,
                 );
 
-                const projectMetadata = JSON.parse(
+                const projectMetadata = this.normalizeProjectMetadata(
+                    projId,
                     this.decodeRemoteTextContent(metadataContent),
                 );
 
@@ -1023,6 +1025,20 @@ export class GitBackupService<TTarget> {
         };
 
         await authDb.put('projects', newProject);
+    }
+
+    private normalizeProjectMetadata(projectId: string, content: string): any {
+        const projectMetadata = JSON.parse(content);
+
+        return {
+            ...projectMetadata,
+            id: projectMetadata.id || projectId,
+            docUrl: projectMetadata.docUrl || `yjs:${projectId}`,
+        };
+    }
+
+    private getErrorMessage(error: unknown): string {
+        return error instanceof Error ? error.message : String(error);
     }
 
     private async importProjectSafely(

--- a/src/services/GitBackupService.ts
+++ b/src/services/GitBackupService.ts
@@ -138,6 +138,34 @@ export class GitBackupService<TTarget> {
 
     constructor(private adapter: GitBackupAdapter<TTarget>) { }
 
+    private binaryStringToArrayBuffer(content: string): ArrayBuffer {
+        const bytes = new Uint8Array(content.length);
+
+        for (let i = 0; i < content.length; i++) {
+            bytes[i] = content.charCodeAt(i);
+        }
+
+        return bytes.buffer;
+    }
+
+    private decodeRemoteFileContent(
+        content: string,
+        isBinary: boolean,
+    ): string | ArrayBuffer {
+        const buffer = this.binaryStringToArrayBuffer(content);
+        if (isBinary) return buffer;
+
+        try {
+            return new TextDecoder('utf-8').decode(buffer);
+        } catch {
+            return content;
+        }
+    }
+
+    private decodeRemoteTextContent(content: string): string {
+        return this.decodeRemoteFileContent(content, false) as string;
+    }
+
     setSettings(settings: GitBackupSettings): void {
         this.settingsCache = { ...settings };
 
@@ -691,7 +719,9 @@ export class GitBackupService<TTarget> {
                         finalBranch,
                     );
 
-                    const projectMetadata = JSON.parse(metadataContent);
+                    const projectMetadata = JSON.parse(
+                        this.decodeRemoteTextContent(metadataContent),
+                    );
 
                     await this.createProjectDirectly(projectMetadata, user.id);
 
@@ -738,7 +768,9 @@ export class GitBackupService<TTarget> {
                     finalBranch,
                 );
 
-                const projectMetadata = JSON.parse(metadataContent);
+                const projectMetadata = JSON.parse(
+                    this.decodeRemoteTextContent(metadataContent),
+                );
 
                 await this.importProjectSafely(
                     projId,
@@ -1021,7 +1053,9 @@ export class GitBackupService<TTarget> {
                     branch,
                 );
 
-                remoteDocumentsMetadata = JSON.parse(metadataContent);
+                remoteDocumentsMetadata = JSON.parse(
+                    this.decodeRemoteTextContent(metadataContent),
+                );
             } catch (error) {
                 console.error('Failed to load documents metadata from remote:', error);
             }
@@ -1055,12 +1089,14 @@ export class GitBackupService<TTarget> {
             } = {};
 
             if (docData.txtRef) {
-                contentData.readableContent = await this.adapter.readFile(
+                const readableContent = await this.adapter.readFile(
                     credentials.token,
                     credentials.target,
                     docData.txtRef,
                     branch,
                 );
+                contentData.readableContent =
+                    this.decodeRemoteTextContent(readableContent);
             }
 
             if (docData.yjsRef) {
@@ -1112,7 +1148,9 @@ export class GitBackupService<TTarget> {
                     branch,
                 );
 
-                remoteFilesMetadata = JSON.parse(metadataContent);
+                remoteFilesMetadata = JSON.parse(
+                    this.decodeRemoteTextContent(metadataContent),
+                );
             } catch (error) {
                 console.error('Failed to load files metadata from remote:', error);
             }
@@ -1193,19 +1231,10 @@ export class GitBackupService<TTarget> {
                     ? remoteMetadata.isBinary
                     : isBinaryFile(filePath);
 
-                let finalContent: string | ArrayBuffer;
-
-                if (isBinary) {
-                    const uint8Array = new Uint8Array(rawContentString.length);
-
-                    for (let i = 0; i < rawContentString.length; i++) {
-                        uint8Array[i] = rawContentString.charCodeAt(i);
-                    }
-
-                    finalContent = uint8Array.buffer;
-                } else {
-                    finalContent = rawContentString;
-                }
+                const finalContent = this.decodeRemoteFileContent(
+                    rawContentString,
+                    isBinary,
+                );
 
                 const fileSize =
                     finalContent instanceof ArrayBuffer

--- a/src/services/GitBackupService.ts
+++ b/src/services/GitBackupService.ts
@@ -955,7 +955,7 @@ export class GitBackupService<TTarget> {
             }
 
             const projectData = projectFiles.get(currentProjectId)!;
-            const ref = item.path;
+            const ref = this.getFileRef(item, item.path, branch);
 
             if (pathParts[2] === 'metadata.json') {
                 projectData.metadataRef = ref;


### PR DESCRIPTION
Hola equipo de TeXlyre,

Encontramos y corregimos un bug en la importación desde GitHub relacionado con archivos UTF-8. Al importar documentos con caracteres acentuados, por ejemplo:

\chapter{EL PROBLEMA DE INVESTIGACIÓN}

el texto quedaba corrupto como:

\chapter{EL PROBLEMA DE INVESTIGACIÃ...}

La causa parece estar en que los blobs de GitHub se leen desde base64 con atob(), pero luego esa “binary string” se trata como texto normal en vez de reconstruir bytes y decodificarlos con UTF-8.

Aplicamos un fix en nuestro fork:

https://github.com/juancah27/texlyre

Commit:

866f168 Fix GitHub import UTF-8 decoding

El cambio decodifica correctamente el contenido remoto con TextDecoder('utf-8') para textos y JSON, y mantiene binarios/Yjs como bytes. También validamos que el build pase con TypeScript.

¿Podrían revisarlo para ver si puede integrarse en la versión oficial web?