### PR TITLE
Added host theme toggle for embedded TikZ editor

### DIFF
--- a/extras/viewers/tikz/TikzViewer.tsx
+++ b/extras/viewers/tikz/TikzViewer.tsx
@@ -19,6 +19,7 @@ import './styles.css';
 import { PLUGIN_NAME, PLUGIN_VERSION } from './TikzViewerPlugin';
 
 const BASE_PATH = __BASE_PATH__;
+const TIKZ_STORAGE_KEY = 'texlyre:tikz-editor:storage';
 
 const DEFAULT_TIKZ_SOURCE = `\begin{tikzpicture}
   \draw[thick, blue] (0,0) circle (1cm);
@@ -46,6 +47,8 @@ type TikzEmbedMessage = {
 	modified?: boolean;
 	version?: string;
 	settings?: TikzHostSettings;
+	key?: string;
+	value?: string;
 	[key: string]: unknown;
 };
 
@@ -141,7 +144,10 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 		() => new URL(baseUrl, window.location.origin).origin,
 		[baseUrl],
 	);
-	const embedUrl = useMemo(() => `${baseUrl}/index.html`, [baseUrl]);
+	const embedUrl = useMemo(() => {
+		const storage = window.localStorage.getItem(TIKZ_STORAGE_KEY);
+		return `${baseUrl}/index.html${storage ? `#storage=${encodeURIComponent(storage)}` : ''}`;
+	}, [baseUrl]);
 	const tikzHostSettings = useMemo<TikzHostSettings>(
 		() => ({ general: { colorScheme: tikzColorScheme } }),
 		[tikzColorScheme],
@@ -258,6 +264,16 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 
 			try {
 				const message = JSON.parse(event.data) as TikzEmbedMessage;
+				if (
+					message.event === 'persistence-save' &&
+					typeof message.key === 'string' &&
+					typeof message.value === 'string'
+				) {
+					const storage = JSON.parse(window.localStorage.getItem(TIKZ_STORAGE_KEY) || '{}') as Record<string, string>;
+					storage[message.key] = message.value;
+					window.localStorage.setItem(TIKZ_STORAGE_KEY, JSON.stringify(storage));
+					return;
+				}
 				if (message.error) {
 					if (pendingExportRef.current) {
 						pendingExportRef.current.reject(new Error(String(message.error)));

--- a/extras/viewers/tikz/TikzViewer.tsx
+++ b/extras/viewers/tikz/TikzViewer.tsx
@@ -20,11 +20,19 @@ import { PLUGIN_NAME, PLUGIN_VERSION } from './TikzViewerPlugin';
 
 const BASE_PATH = __BASE_PATH__;
 
-const DEFAULT_TIKZ_SOURCE = `\\begin{tikzpicture}
-  \\draw[thick, blue] (0,0) circle (1cm);
-  \\node at (0,0) {TikZ};
-\\end{tikzpicture}
+const DEFAULT_TIKZ_SOURCE = `\begin{tikzpicture}
+  \draw[thick, blue] (0,0) circle (1cm);
+  \node at (0,0) {TikZ};
+\end{tikzpicture}
 `;
+
+type TikzColorScheme = 'light' | 'dark';
+
+type TikzHostSettings = {
+	general?: {
+		colorScheme?: TikzColorScheme;
+	};
+};
 
 type TikzEmbedMessage = {
 	event?: string;
@@ -37,6 +45,7 @@ type TikzEmbedMessage = {
 	fileName?: string;
 	modified?: boolean;
 	version?: string;
+	settings?: TikzHostSettings;
 	[key: string]: unknown;
 };
 
@@ -113,6 +122,8 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 	const [tikzSource, setTikzSource] = useState('');
 	const [iframeLoaded, setIframeLoaded] = useState(false);
 	const [showSaveIndicator, setShowSaveIndicator] = useState(false);
+	const [tikzColorScheme, setTikzColorScheme] =
+		useState<TikzColorScheme>('light');
 
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const sourceRef = useRef('');
@@ -131,6 +142,10 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 		[baseUrl],
 	);
 	const embedUrl = useMemo(() => `${baseUrl}/index.html`, [baseUrl]);
+	const tikzHostSettings = useMemo<TikzHostSettings>(
+		() => ({ general: { colorScheme: tikzColorScheme } }),
+		[tikzColorScheme],
+	);
 
 	useEffect(() => {
 		return () => {
@@ -201,6 +216,11 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 		[iframeLoaded, tikzOrigin],
 	);
 
+	useEffect(() => {
+		if (!iframeLoaded) return;
+		sendMessageToTikz({ action: 'settings', settings: tikzHostSettings });
+	}, [iframeLoaded, sendMessageToTikz, tikzHostSettings]);
+
 	const handleSave = useCallback(
 		async (sourceToSave?: string) => {
 			if (!fileId) return;
@@ -255,6 +275,7 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 						xml: sourceRef.current || tikzSource || DEFAULT_TIKZ_SOURCE,
 						autosave: autoSaveEditor ? 1 : 0,
 						fileName,
+						settings: tikzHostSettings,
 					});
 
 					while (messageQueueRef.current.length > 0) {
@@ -328,6 +349,7 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 			fileId,
 			fileName,
 			handleSave,
+			tikzHostSettings,
 		],
 	);
 
@@ -397,6 +419,10 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 		sendMessageToTikz({ action: 'save' });
 	}, [sendMessageToTikz]);
 
+	const handleToggleTikzTheme = useCallback(() => {
+		setTikzColorScheme((scheme) => (scheme === 'light' ? 'dark' : 'light'));
+	}, []);
+
 	const tooltipInfo = [
 		t('Auto-save editor: {status}', {
 			status: autoSaveEditor ? t('enabled') : t('disabled'),
@@ -404,6 +430,7 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 		t('Auto-save file: {status}', {
 			status: autoSaveFile ? t('enabled') : t('disabled'),
 		}),
+		t('TikZ theme: {theme}', { theme: t(tikzColorScheme) }),
 		t('MIME Type: {mimeType}', {
 			mimeType: fileInfo.mimeType || 'text/x-tex',
 		}),
@@ -436,6 +463,13 @@ const TikzViewer: React.FC<ViewerProps> = ({ content, fileName, fileId }) => {
 					disabled={!iframeLoaded}
 				>
 					SVG
+				</button>
+				<button
+					onClick={handleToggleTikzTheme}
+					title={t('Toggle TikZ editor theme')}
+					disabled={!iframeLoaded}
+				>
+					{tikzColorScheme === 'light' ? t('Dark') : t('Light')}
 				</button>
 			</PluginControlGroup>
 		</>


### PR DESCRIPTION
This is intended to test the host-to-embed settings bridge from `tikz-editor-embed-mirror` PR #3. It does not add TikZ editor setting persistence; TeXlyre remains the source of truth for the setting value.

- Add a temporary host-side Light/Dark toggle to the TikZ viewer header.
- Send `settings.general.colorScheme` to the embedded TikZ editor during load.
- Send `action: settings` whenever the host toggle changes.


