### PR TITLE
Use argon2id in AuthService

### DIFF
--- a/src/contexts/SecretsContext.tsx
+++ b/src/contexts/SecretsContext.tsx
@@ -139,17 +139,6 @@ export const SecretsProvider: React.FC<SecretsProviderProps> = ({
 		[],
 	);
 
-	const _hashWithPassword = useCallback(
-		async (data: string, password: string): Promise<string> => {
-			const encoder = new TextEncoder();
-			const combined = encoder.encode(data + password);
-			const hashBuffer = await crypto.subtle.digest('SHA-256', combined);
-			const hashArray = Array.from(new Uint8Array(hashBuffer));
-			return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-		},
-		[],
-	);
-
 	const encryptWithPassword = useCallback(
 		async (data: string, password: string): Promise<string> => {
 			const encoder = new TextEncoder();

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -2,6 +2,7 @@
 import { type IDBPDatabase, openDB } from 'idb';
 import { IndexeddbPersistence } from 'y-indexeddb';
 import * as Y from 'yjs';
+import { argon2id, argon2Verify } from "hash-wasm";
 
 import { t } from '@/i18n';
 import type { User } from '../types/auth';
@@ -80,13 +81,6 @@ class AuthService {
 			console.error('Failed to initialize database:', error);
 			throw error;
 		}
-	}
-
-	async hashPassword(password: string): Promise<string> {
-		const msgBuffer = new TextEncoder().encode(password);
-		const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
-		const hashArray = Array.from(new Uint8Array(hashBuffer));
-		return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
 	}
 
 	generateSessionId(): string {
@@ -377,8 +371,7 @@ class AuthService {
 			throw new Error(t('User not found'));
 		}
 
-		const passwordHash = await this.hashPassword(password);
-		if (user.passwordHash !== passwordHash) {
+		if (!this.verifyPasswordHash(user.passwordHash, password)) {
 			throw new Error(t('Invalid password'));
 		}
 
@@ -470,14 +463,31 @@ class AuthService {
 		return !!this.currentUser;
 	}
 
+	async hashPassword(password: string): Promise<string> {
+		const salt = new Uint8Array(16);
+		window.crypto.getRandomValues(salt);
+		return argon2id({
+			password,
+			salt,
+			iterations: 3,
+			memorySize: 64 * 1024,
+			parallelism: 1,
+			hashLength: 32,
+			outputType: "encoded",
+		});
+	}
+
+	private async verifyPasswordHash(passwordHash: string, password: string): Promise<boolean> {
+		return argon2Verify({ password, hash: passwordHash });
+	}
+
 	async verifyPassword(userId: string, password: string): Promise<boolean> {
 		if (!this.db) await this.initialize();
 
 		const user = await this.getUserById(userId);
 		if (!user) return false;
 
-		const passwordHash = await this.hashPassword(password);
-		return user.passwordHash === passwordHash;
+		return this.verifyPasswordHash(user.passwordHash, password);
 	}
 
 	async updatePassword(userId: string, newPassword: string): Promise<User> {

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -463,6 +463,17 @@ class AuthService {
 		return !!this.currentUser;
 	}
 
+	private async hashPasswordOld(password: string): Promise<string> {
+		const msgBuffer = new TextEncoder().encode(password);
+		const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+		const hashArray = Array.from(new Uint8Array(hashBuffer));
+		return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+	}
+
+	private async verifyPasswordHashOld(passwordHash: string, password: string): Promise<boolean> {
+		return passwordHash === await this.hashPasswordOld(password);
+	}
+
 	async hashPassword(password: string): Promise<string> {
 		const salt = new Uint8Array(16);
 		window.crypto.getRandomValues(salt);
@@ -484,8 +495,16 @@ class AuthService {
 	async verifyPassword(userId: string, password: string): Promise<boolean> {
 		if (!this.db) await this.initialize();
 
-		const user = await this.getUserById(userId);
+		let user = await this.getUserById(userId);
 		if (!user) return false;
+
+		// update user.passwordHash if old hashing method is used
+		if (!user.passwordHash.startsWith("$argon2")) {
+			const isValid = await this.verifyPasswordHashOld(user.passwordHash, password);
+			if (isValid) {
+				user = await this.updatePassword(user.id, password);
+			}
+		}
 
 		return this.verifyPasswordHash(user.passwordHash, password);
 	}


### PR DESCRIPTION
Hi, thanks for this great project!

I looked at the texlyre code and I know this comes just out of nowhere without previous discussion, but I noticed that texlyre uses SHA-256 for password hashing and you already have a library providing argon2id in your dependencies.
So I went ahead and switched the password hashing code over to argon2id and also included code to migrate from the old hashes.

SHA-256 is fast and it is discouraged to be used for password hashing.
See https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API/Non-cryptographic_uses_of_subtle_crypto#what_is_salting_the_hash and https://www.latacora.com/blog/post-quantum-cryptographic-right-answers/#password-handling

I believe comparing passwords with `===` is not constant-time but I am not sure if this is even relevant in JS world...

`npm run lint` errored out on me but local testing with `npm run dev` was still successful.

I hope this code is of use to this project. :)